### PR TITLE
Fix SponsorBlock zero videoDuration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- A bug where SponsorBlock returning videoDuration of zero causes the app to hang
+
 ## [0.5.0] - 2022-12-02
 ### Added
 - Version check in settings page

--- a/src/components/VideoPlayer/SponsorBlockTask.bs
+++ b/src/components/VideoPlayer/SponsorBlockTask.bs
@@ -4,8 +4,19 @@ function TaskMain()
     input = m.top.getField("input")
     videoId = input.videoId
 
-    skipSegments = SponsorBlock.GetSkipSegmentsForVideo(videoId)
+    sponsorBlockResponse = SponsorBlock.GetSkipSegmentsForVideo(videoId)
     barPath = invalid
+
+    skipSegments = []
+    for each segment in sponsorBlockResponse
+        if segment.videoDuration > 0
+            skipSegments.push(segment)
+        end if
+    end for
+
+    if skipSegments.Count() = 0
+        skipSegments = invalid
+    end if
 
     if skipSegments <> invalid
         barPath = `tmp:/sponsorblock_bar_${videoId}.png`


### PR DESCRIPTION
Fixes a bug where SponsorBlock reports that the video has a duration of zero.

Reported from Reddit https://www.reddit.com/r/selfhosted/comments/zb07p0/comment/iyq52av/?utm_source=share&utm_medium=web2x&context=3