### PR TITLE
Use format streams by default instead of DASH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Crash in case GetLocalIpAddress() returns invalid
+- Use Format Stream (720p) instead of DASH (https://github.com/iv-org/invidious/issues/3666)
 
 ## [0.7.0] - 2023-02-04
 ### Added

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -117,6 +117,14 @@ function OnVideoDetailsTaskResults(output as object) as void
         end if
         playletStreamUrls.push(hlsUrlLocal)
     else
+        if metadata.formatStreams.Count() > 0
+            stream = metadata.formatStreams[metadata.formatStreams.Count() - 1]
+            itag = stream.itag
+
+            playletStreamUrls.push(Invidious.GetVideoUrl(videoId, itag, false))
+            playletStreamUrls.push(Invidious.GetVideoUrl(videoId, itag, true))
+        end if
+
         if metadata.dashUrl <> invalid
 
             #if DASH_THUMBNAILS
@@ -135,13 +143,6 @@ function OnVideoDetailsTaskResults(output as object) as void
             playletStreamUrls.push(dashUrlLocal)
         end if
 
-        if metadata.formatStreams.Count() > 0
-            stream = metadata.formatStreams[metadata.formatStreams.Count() - 1]
-            itag = stream.itag
-
-            playletStreamUrls.push(Invidious.GetVideoUrl(videoId, itag, false))
-            playletStreamUrls.push(Invidious.GetVideoUrl(videoId, itag, true))
-        end if
     end if
 
     metadata.playletStreamUrls = playletStreamUrls


### PR DESCRIPTION
This is a temporary fix for the low quality videos playing currently because of https://github.com/iv-org/invidious/issues/3666 
This will be addressed better by introducing a quality selector.