### PR TITLE
Add the ability to find a working caption

### DIFF
--- a/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptions.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptions.bs
@@ -1,3 +1,5 @@
+import "pkg:/components/VideoPlayer/VideoPlayerCaptionsTask.bs"
+
 function SetCaptions(metadata as object, videoPlayer as object, contentNode as object) as void
     if metadata.captions.Count() = 0
         return
@@ -18,4 +20,35 @@ function SetCaptions(metadata as object, videoPlayer as object, contentNode as o
     end for
     contentNode.ClosedCaptions = True
     contentNode.SubtitleTracks = subtitleTracks
+
+    ' Searching for a working caption could cause a delay in the video player start.
+    ' This is why it is behind a feature flag.
+    #if CAPTION_INSTANCE_SEARCH
+        StartAsyncTask(VideoPlayerCaptionsTask, {
+            videoId: metadata.videoId,
+            instance: instance,
+            subtitleTracks: subtitleTracks
+        }, OnVideoPlayerCaptionsTaskResults)
+    #end if
+end function
+
+function OnVideoPlayerCaptionsTaskResults(output as object) as void
+    changed = output.result.changed
+    if not changed
+        return
+    end if
+
+    videoId = output.result.videoId
+    if m.top.videoId <> videoId
+        return
+    end if
+
+    state = m.top.state
+    contentNode = m.top.content
+    contentNode.Update({
+        SubtitleTracks: output.result.subtitleTracks
+    })
+    if state = "buffering" or state = "playing"
+        m.top.control = "play"
+    end if
 end function

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptionsTask.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptionsTask.bs
@@ -1,0 +1,62 @@
+import "pkg:/source/roku_modules/rokurequests/Requests.brs"
+import "pkg:/source/services/InvidiousSettings.bs"
+
+@asynctask
+function VideoPlayerCaptionsTask(input as object) as object
+    originalInstance = input.instance
+    subtitleTracks = input.subtitleTracks
+    if subtitleTracks.Count() = 0
+        return {
+            changed: false
+        }
+    end if
+
+    track = subtitleTracks[0]
+    url = track.TrackName
+
+    if IsValidSubtitleTrack(url)
+        return {
+            changed: false
+        }
+    end if
+
+    failedInstances = {}
+    failedInstances[originalInstance] = true
+
+    instances = InvidiousSettings.GetCurrentInstances()
+    for each instance in instances
+        if failedInstances[instance] = true
+            continue for
+        end if
+
+        instanceUrl = url.Replace(originalInstance, instance)
+        if IsValidSubtitleTrack(instanceUrl)
+            for i = 0 to subtitleTracks.Count() - 1
+                subtitleTracks[i].TrackName = subtitleTracks[i].TrackName.Replace(originalInstance, instance)
+            end for
+
+            return {
+                changed: true,
+                videoId: input.videoId,
+                subtitleTracks: subtitleTracks
+            }
+        else
+            failedInstances[instance] = true
+        end if
+
+    end for
+
+    return {
+        changed: false
+    }
+end function
+
+function IsValidSubtitleTrack(url as string) as boolean
+    response = Requests().get(url, {parseJson: false})
+    ' A popular instance will return a valid format
+    '   WEBVTT
+    '   Kind: captions
+    '   Language: en
+    ' But won't include any caption items
+    return response.ok and response.text.StartsWith("WEBVTT") and response.text.len() > 50
+end function

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptionsTask.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayerCaptionsTask.bs
@@ -52,7 +52,7 @@ function VideoPlayerCaptionsTask(input as object) as object
 end function
 
 function IsValidSubtitleTrack(url as string) as boolean
-    response = Requests().get(url, {parseJson: false})
+    response = Requests().get(url, { parseJson: false })
     ' A popular instance will return a valid format
     '   WEBVTT
     '   Kind: captions

--- a/playlet-lib/src/manifest
+++ b/playlet-lib/src/manifest
@@ -10,4 +10,4 @@ hidden=1
 
 git_commit_sha=unknown
 
-bs_const=DEBUG=false;WEB_SERVER_BASIC_AUTH=false;DASH_THUMBNAILS=false;WEB_SOCKETS=true
+bs_const=DEBUG=false;WEB_SERVER_BASIC_AUTH=false;DASH_THUMBNAILS=false;WEB_SOCKETS=true;CAPTION_INSTANCE_SEARCH=false

--- a/playlet-lib/src/source/services/InvidiousSettings.bs
+++ b/playlet-lib/src/source/services/InvidiousSettings.bs
@@ -1,3 +1,5 @@
+import "pkg:/source/utils/RegistryUtils.bs"
+
 namespace InvidiousSettings
 
     const DEFAULT_INSTANCE = "https://vid.puffyan.us"


### PR DESCRIPTION
This adds the ability to find a working caption in case the main instance is popular and not returning a valid caption
This feature is behind a flag for now, because it seems to delay the start of videos (when setting the caption to the ContentNode after start, the player would rebuffer again)