### PR TITLE
Remove workaround for Invidious token expiring due to misconfigured instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Video duration formatting in cast dialog
+- (Removed) Workaround for Invidious token expiring due to misconfigured instance
 
 ## [0.10.1] - 2023-06-28
 

--- a/playlet-lib/src/source/services/InvidiousService.bs
+++ b/playlet-lib/src/source/services/InvidiousService.bs
@@ -147,33 +147,10 @@ class InvidiousService
 
     function DeleteExpiredToken(response as object)
         if response.statuscode = 403
-            print(`Server responded with 403: ${response.text}`)
-            if m.IsTokenMaybeExpired() = true
-                print("deleting token...")
-                RegistryUtils.Delete(RegistryUtils.INVIDIOUS_TOKEN)
-            end if
+            print(`Invidious instance responded with 403: ${response.text}`)
+            print("Deleting Invidious token...")
+            RegistryUtils.Delete(RegistryUtils.INVIDIOUS_TOKEN)
         end if
-    end function
-
-    ' Public Invidious instances fail a lot randomly, even with valid tokens
-    ' For that reason, it's better to make sure the token actually expired by date
-    ' TODO: this happens because instance owners do not set hmac_key https://github.com/iv-org/invidious/issues/3854
-    ' Once hmac_key is enforced, this check can be removed.
-    function IsTokenMaybeExpired() as dynamic
-        authToken = InvidiousSettings.GetAuthToken()
-        if authToken = invalid
-            return invalid
-        end if
-        token = ParseJson(authToken.token)
-        if token = invalid
-            return invalid
-        end if
-        if not token.DoesExist("expire")
-            return invalid
-        end if
-        expire = token["expire"]
-        currentTime = TimeUtils.Now().AsSeconds()
-        return expire < currentTime
     end function
 
     function CacheResponse(requestData as object, result as object)


### PR DESCRIPTION
Since this is done https://github.com/iv-org/invidious/pull/3955 we no longer need to do these weird checks on the token.
A 403 from Invidious means an invalid token that should be deleted.