### PR TITLE
Create an xml include plugin

### DIFF
--- a/config/bsconfig.base.json
+++ b/config/bsconfig.base.json
@@ -24,7 +24,8 @@
         "roku-log-bsc-plugin",
         "@rokucommunity/bslint",
         "../tools/bs-plugins/asynctask-plugin.ts",
-        "../tools/bs-plugins/manifest-bsconst-debug-plugin.ts"
+        "../tools/bs-plugins/manifest-bsconst-debug-plugin.ts",
+        "../tools/bs-plugins/component-includes-plugin.ts"
     ],
     "retainStagingDir": true,
     "require": [

--- a/tools/bs-plugins/component-includes-plugin.ts
+++ b/tools/bs-plugins/component-includes-plugin.ts
@@ -1,0 +1,130 @@
+import {
+    BeforeFileTranspileEvent,
+    CompilerPlugin,
+    XmlFile,
+    isXmlFile,
+    util,
+} from 'brighterscript';
+import { SGChildren, SGComponent, SGField, SGFunction, SGInterface, SGNode, SGScript } from 'brighterscript/dist/parser/SGTypes';
+
+export class ComponentIncludesPlugin implements CompilerPlugin {
+    public name = 'ComponentIncludesPlugin';
+
+    private processedXmlFiles: { [key: string]: boolean } = {};
+
+    beforeFileTranspile(event: BeforeFileTranspileEvent) {
+        if (!isXmlFile(event.file)) {
+            return;
+        }
+
+        this.processXmlFile(event.file);
+    }
+
+    processXmlFile(xmlFile: XmlFile) {
+        if (this.processedXmlFiles[xmlFile.srcPath]) {
+            return;
+        }
+
+        this.processedXmlFiles[xmlFile.srcPath] = true;
+
+        const program = xmlFile.program;
+        const component = xmlFile.parser.ast.component;
+
+        if (!component || !component.attributes) {
+            return;
+        }
+
+        const includes = this.getIncludes(component);
+        if (includes.length === 0) {
+            return;
+        }
+
+        for (let i = 0; i < includes.length; i++) {
+            const include = includes[i];
+            const includeXmlFile = program.getComponent(include).file;
+
+            this.processXmlFile(includeXmlFile);
+
+            const { scripts, fields, functions, children } = this.getIncludeItems(includeXmlFile);
+
+            if (scripts) {
+                component.scripts.push(...scripts);
+            }
+
+            if (fields || functions) {
+                if (!component.api) {
+                    component.api = new SGInterface();
+                }
+            }
+
+            if (fields) {
+                component.api.fields.push(...fields);
+            }
+
+            if (functions) {
+                component.api.functions.push(...functions);
+            }
+
+            if (children) {
+                if (!component.children) {
+                    component.children = new SGChildren();
+                }
+
+                component.children.children.push(...children);
+            }
+        }
+
+        component.attributes = component.attributes.filter((attr) => {
+            return attr.key.text !== 'includes';
+        });
+    }
+
+    getIncludes(component: SGComponent) {
+        return component.attributes.filter((attr) => {
+            return attr.key.text === 'includes';
+        }).map((attr) => {
+            return attr.value.text.split(',').map((item) => {
+                return item.trim();
+            });
+        }).flat();
+    }
+
+    getIncludeItems(xmlFile: XmlFile) {
+        let fields: SGField[] = [];
+        let functions: SGFunction[] = [];
+        let children: SGNode[] = [];
+        let scripts: SGScript[] = [];
+
+        const component = xmlFile.parser.ast.component;
+        if (!component) {
+            return { fields, functions, children, scripts };
+        }
+
+        const scriptImports = xmlFile.getAvailableScriptImports();
+        scripts = scriptImports.map((scriptImport) => {
+            const script = new SGScript();
+            script.uri = util.getRokuPkgPath(scriptImport);
+            return script;
+        });
+
+        if (component.api) {
+            fields = component.api.fields;
+            functions = component.api.functions;
+        }
+
+        if (component.children) {
+            children = component.children.children;
+        }
+
+        return {
+            scripts,
+            fields,
+            functions,
+            children,
+        }
+    }
+}
+
+export default () => {
+    return new ComponentIncludesPlugin();
+};


### PR DESCRIPTION
Create a plugin that adds the `"include"` capability to components. For example:

```
<component name="MainScene" extends="Group" includes="TestComponent, TestComponent3">
    <children>
        <Label text="Hello World!" />
    </children>
</component>
```
Could transpile to something like
```
<?xml version="1.0" encoding="UTF-8" ?>
<component name="MainScene" extends="Group">
    <interface>
        <field id="some_field" type="integer" value="3" />
        <field id="some_field_sub" type="integer" value="5" />
        <field id="some_field_4" type="integer" value="12" />
        <function name="ARegisteredFunction" />
        <function name="SubComponentFunction" />
    </interface>
    <script type="text/brightscript" uri="pkg:/components/TestComponent/TestComponent2.brs" />
    <script type="text/brightscript" uri="pkg:/components/TestComponent/TestComponent.brs" />
    <script type="text/brightscript" uri="pkg:/source/roku_modules/bslib/bslib.brs" />
    <script type="text/brightscript" uri="pkg:/source/roku_modules/rokurequests/Requests.brs" />
    <script type="text/brightscript" uri="pkg:/source/roku_modules/bslib/bslib.brs" />
    <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
    <script type="text/brightscript" uri="pkg:/source/roku_modules/bslib/bslib.brs" />
    <children>
        <Label text="Hello World!" />
        <Label text="Hello World! From TestSub" />
    </children>
</component>
<!--//# sourceMappingURL=./MainScene.xml.map -->
```


All fields, functions, script references and children from `TestComponent` and `TestComponent3` will be copied over to `MyComponent`.

 This should improve the modularity a bit and make code reuse easier.