### PR TITLE
OK button as Play/Pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Small improvement in the context menu of the Playlist view
+- Videos can be paused and resumed using the `Ok` remote button
 
 ## [0.20.1] - 2024-02-23
 

--- a/playlet-lib/src/components/VideoPlayer/VideoContentTask.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoContentTask.bs
@@ -34,6 +34,7 @@ function VideoContentTask(input as object) as object
 
     contentNode.title = metadata.title
     contentNode.secondaryTitle = metadata.author
+    contentNode.live = metadata.liveNow
 
     streamUrls = CreateStreamUrls(metadata, service, preferencesNode, playletServerPort)
     contentNode.url = streamUrls[0]

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -85,9 +85,6 @@ function PlayWithContent(contentNode as object)
     if not StringUtils.IsNullOrEmpty(contentNode._author)
         videoContentNode.secondaryTitle = contentNode._author
     end if
-    if IsBool(contentNode.liveNow)
-        videoContentNode.live = contentNode.liveNow
-    end if
 
     StartVideoContentTask(videoContentNode)
     Lounge.SendNowPlayingLoading(contentNode.videoId)
@@ -263,7 +260,7 @@ function OnVideoFinished() as void
 end function
 
 function IsLiveVideo() as boolean
-    if m.top.content <> invalid and ValidBool(m.top.content.live)
+    if m.top.content <> invalid
         return m.top.content.live
     end if
     return false

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -16,6 +16,8 @@ function Init()
     m.fullScreenHintLabel = m.top.findNode("fullScreenHintLabel")
     m.fullScreenHintTimer = m.top.findNode("fullScreenHintTimer")
     m.fullScreenHintTimer.ObserveField("fire", FuncName(OnFullScreenHintTimer))
+    m.trickplayUITimer = m.top.findNode("trickplayUITimer")
+    m.trickplayUITimer.ObserveField("fire", FuncName(OnTrickplayUITimer))
 
     ' videoPlayingSuccess indicates if we started playing a video successfully
     ' We use it to detect if we should try another link for a video, or if another error
@@ -25,6 +27,9 @@ function Init()
     ' This is used to prevent the video from playing the next video when we are
     ' still trying to find a working stream url
     m.ignoreNextFinishedState = false
+
+    ' Indicates that we're currently paused and seeking position
+    m.isSeekingPosition = false
 
     ' asyncStopSemantics available since Roku OS 12.5
     ' It is set to true because stopping synchronously causes timeout and crash
@@ -170,6 +175,12 @@ function OnVideoPlayerStateChange() as void
 
     state = m.top.state
     content = m.top.content
+
+    ' Reset isSeekingPosition when started to play the video
+    if state = "playing"
+        m.isSeekingPosition = false
+    end if
+
     ' If we successfully played the video, then any error that comes later is not due to a 403 (FORBIDDEN).
     ' This is to reduce false positives, as we do not want retry another link if the first link is working fine.
     if state = "playing" and not m.videoPlayingSuccess
@@ -244,6 +255,47 @@ function OnVideoFinished() as void
     end if
 end function
 
+function ShowUIAndStartTimer()
+    m.top.showUI = { "show": true, "trickPlaybar": true, "titleAndTime": true, "trickplayBackgroundOverlay": true, "focusTrickplayBar": false }
+    m.trickplayUITimer.control = "start"
+end function
+
+function HandleOKPress() as boolean
+    handled = false
+    state = m.top.state
+    uiVisible = m.top.trickPlaybar.visible
+    LogInfo("OK", state, uiVisible, m.isSeekingPosition)
+    if state = "playing"
+        if not uiVisible
+            ' Video is playing and UI is not visible, show it
+            ShowUIAndStartTimer()
+        else
+            ' Trickplay bar is visible and video is currently played, pause it and retain the UI
+            m.trickplayUITimer.control = "stop"
+            m.top.control = "pause"
+            ShowUIAndStartTimer()
+        end if
+        handled = true
+    else if state = "paused"
+        ' Exit early if we're in seeking mode to avoid messing up internal Video node state
+        if m.isSeekingPosition
+            return false
+        end if
+
+        if not uiVisible
+            ' Video is paused and UI is not visible, show it
+            ShowUIAndStartTimer()
+        else
+            ' Video is currently paused with visible UI, resume it and hide UI
+            m.trickplayUITimer.control = "stop"
+            HideUI()
+            m.top.control = "resume"
+        end if
+        handled = true
+    end if
+    return handled
+end function
+
 function OnkeyEvent(key as string, press as boolean) as boolean
     if press = false
         return false
@@ -261,6 +313,21 @@ function OnkeyEvent(key as string, press as boolean) as boolean
         m.videoQueue.closePlayer = true
         return true
     end if
+
+    if key = "OK"
+        return HandleOKPress()
+    end if
+
+    if key = "left" or key = "right" or key = "rewind" or key = "fastforward"
+        if m.top.state = "paused"
+            ' We're paused and pressed on of the buttons: left, right ff, rw.
+            ' That means we're seeking position. Check that in HandleOKPress and exit early
+            m.isSeekingPosition = true
+        end if
+    end if
+
+    ' Always stop UI timer when pressing any button to avoid UI being hidden twice
+    m.trickplayUITimer.control = "stop"
     return false
 end function
 
@@ -311,6 +378,14 @@ function OnShowFullScreenHint() as void
     end if
 
     m.fullScreenHintTimer.control = "start"
+end function
+
+function HideUI()
+    m.top.showUI = { "show": false, "focusTrickplayBar": false }
+end function
+
+function OnTrickplayUITimer()
+    HideUI()
 end function
 
 function OnFullScreenHintTimer()

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -320,7 +320,7 @@ function OnkeyEvent(key as string, press as boolean) as boolean
 
     if key = "left" or key = "right" or key = "rewind" or key = "fastforward"
         if m.top.state = "paused"
-            ' We're paused and pressed on of the buttons: left, right ff, rw.
+            ' We're paused and one of the buttons is pressed: left, right ff, rw.
             ' That means we're seeking position. Check that in HandleOKPress and exit early
             m.isSeekingPosition = true
         end if

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -260,6 +260,10 @@ function ShowUIAndStartTimer()
     m.trickplayUITimer.control = "start"
 end function
 
+function HideUI()
+    m.top.showUI = { "show": false, "focusTrickplayBar": false }
+end function
+
 function HandleOKPress() as boolean
     handled = false
     state = m.top.state
@@ -378,10 +382,6 @@ function OnShowFullScreenHint() as void
     end if
 
     m.fullScreenHintTimer.control = "start"
-end function
-
-function HideUI()
-    m.top.showUI = { "show": false, "focusTrickplayBar": false }
 end function
 
 function OnTrickplayUITimer()

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.bs
@@ -31,6 +31,10 @@ function Init()
     ' Indicates that we're currently paused and seeking position
     m.isSeekingPosition = false
 
+    ' Checks if current RokuOS version has showUI field in Video node
+    m.showUIEnabled = m.top.hasField("showUI")
+    LogInfo(`Custom OK handler is ${m.showUIEnabled ? "enabled" : "disabled"}`)
+
     ' asyncStopSemantics available since Roku OS 12.5
     ' It is set to true because stopping synchronously causes timeout and crash
     ' Usually we would need to wait for the video state to move to "stopping" then to "stopped"
@@ -80,6 +84,9 @@ function PlayWithContent(contentNode as object)
     ' NOTE: "_author" not "author". See PlaylistContentNode.xml for explanation.
     if not StringUtils.IsNullOrEmpty(contentNode._author)
         videoContentNode.secondaryTitle = contentNode._author
+    end if
+    if IsBool(contentNode.liveNow)
+        videoContentNode.live = contentNode.liveNow
     end if
 
     StartVideoContentTask(videoContentNode)
@@ -255,29 +262,48 @@ function OnVideoFinished() as void
     end if
 end function
 
-function ShowUIAndStartTimer()
-    m.top.showUI = { "show": true, "trickPlaybar": true, "titleAndTime": true, "trickplayBackgroundOverlay": true, "focusTrickplayBar": false }
-    m.trickplayUITimer.control = "start"
+function IsLiveVideo() as boolean
+    if m.top.content <> invalid and ValidBool(m.top.content.live)
+        return m.top.content.live
+    end if
+    return false
 end function
 
-function HideUI()
-    m.top.showUI = { "show": false, "focusTrickplayBar": false }
+function ShowUIAndStartTimer()
+    if m.showUIEnabled
+        m.top.showUI = { "show": true, "trickPlaybar": true, "titleAndTime": true, "trickplayBackgroundOverlay": true, "focusTrickplayBar": false }
+        m.trickplayUITimer.control = "start"
+    end if
+end function
+
+function HideUIAndStopTimer()
+    if m.showUIEnabled
+        m.top.showUI = { "show": false, "focusTrickplayBar": false }
+        m.trickplayUITimer.control = "stop"
+    end if
 end function
 
 function HandleOKPress() as boolean
+    if not m.showUIEnabled
+        return false
+    end if
+
     handled = false
     state = m.top.state
     uiVisible = m.top.trickPlaybar.visible
-    LogInfo("OK", state, uiVisible, m.isSeekingPosition)
+    isLive = IsLiveVideo()
+    LogInfo(`Handling OK button: state = ${state}, uiVisible = ${uiVisible} isLive = ${isLive}`)
     if state = "playing"
         if not uiVisible
             ' Video is playing and UI is not visible, show it
             ShowUIAndStartTimer()
-        else
+        else if not isLive
             ' Trickplay bar is visible and video is currently played, pause it and retain the UI
             m.trickplayUITimer.control = "stop"
             m.top.control = "pause"
             ShowUIAndStartTimer()
+        else
+            HideUIAndStopTimer()
         end if
         handled = true
     else if state = "paused"
@@ -291,8 +317,7 @@ function HandleOKPress() as boolean
             ShowUIAndStartTimer()
         else
             ' Video is currently paused with visible UI, resume it and hide UI
-            m.trickplayUITimer.control = "stop"
-            HideUI()
+            HideUIAndStopTimer()
             m.top.control = "resume"
         end if
         handled = true
@@ -323,11 +348,9 @@ function OnkeyEvent(key as string, press as boolean) as boolean
     end if
 
     if key = "left" or key = "right" or key = "rewind" or key = "fastforward"
-        if m.top.state = "paused"
-            ' We're paused and one of the buttons is pressed: left, right ff, rw.
-            ' That means we're seeking position. Check that in HandleOKPress and exit early
-            m.isSeekingPosition = true
-        end if
+        ' We're paused and one of the buttons is pressed: left, right ff, rw.
+        ' That means we're seeking position. Check that in HandleOKPress and exit early
+        m.isSeekingPosition = true
     end if
 
     ' Always stop UI timer when pressing any button to avoid UI being hidden twice
@@ -353,6 +376,8 @@ function SetupAnimation()
 end function
 
 function OnFullScreenChange()
+    HideUIAndStopTimer()
+
     m.widthInterpolator.reverse = m.container.fullscreen
     m.heightInterpolator.reverse = m.container.fullscreen
     m.translationInterpolator.reverse = m.container.fullscreen
@@ -385,7 +410,7 @@ function OnShowFullScreenHint() as void
 end function
 
 function OnTrickplayUITimer()
-    HideUI()
+    HideUIAndStopTimer()
 end function
 
 function OnFullScreenHintTimer()

--- a/playlet-lib/src/components/VideoPlayer/VideoPlayer.xml
+++ b/playlet-lib/src/components/VideoPlayer/VideoPlayer.xml
@@ -16,53 +16,17 @@
         <function name="Close" />
     </interface>
     <children>
-        <Label
-            id="chapterLabel"
-            width="350"
-            height="25"
-            horizAlign="center"
-            vertAlign="center"
-            font="font:SmallestSystemFont"
-        />
-        <Timer
-            id="chapterLabelTimer"
-            repeat="true"
-            duration="0.25"
-        />
-        <Animation id="minimizeAnimation"
-            duration="0.3"
-            optional="true">
-            <FloatFieldInterpolator
-                id="widthInterpolator"
-                key="[0.0, 0.5, 1.0]"
-                fieldToInterp="VideoPlayer.width" />
-            <FloatFieldInterpolator
-                id="heightInterpolator"
-                key="[0.0, 0.5, 1.0]"
-                fieldToInterp="VideoPlayer.height" />
-            <Vector2DFieldInterpolator
-                id="translationInterpolator"
-                key="[0.0, 0.5, 1.0]"
-                fieldToInterp="VideoPlayer.translation" />
+        <Label id="chapterLabel" width="350" height="25" horizAlign="center" vertAlign="center" font="font:SmallestSystemFont" />
+        <Timer id="chapterLabelTimer" repeat="true" duration="0.25" />
+        <Animation id="minimizeAnimation" duration="0.3" optional="true">
+            <FloatFieldInterpolator id="widthInterpolator" key="[0.0, 0.5, 1.0]" fieldToInterp="VideoPlayer.width" />
+            <FloatFieldInterpolator id="heightInterpolator" key="[0.0, 0.5, 1.0]" fieldToInterp="VideoPlayer.height" />
+            <Vector2DFieldInterpolator id="translationInterpolator" key="[0.0, 0.5, 1.0]" fieldToInterp="VideoPlayer.translation" />
         </Animation>
-        <Rectangle
-            id="fullScreenHint"
-            height="26"
-            color="0x000000"
-            opacity="0.8"
-            visible="false">
-            <Label
-                id="fullScreenHintLabel"
-                text="Press Options (*) for full screen"
-                height="26"
-                color="0xFFFFFF"
-                horizAlign="center"
-                vertAlign="center"
-                font="font:SmallestSystemFont"
-            />
-            <Timer
-                id="fullScreenHintTimer"
-                duration="5" />
+        <Rectangle id="fullScreenHint" height="26" color="0x000000" opacity="0.8" visible="false">
+            <Label id="fullScreenHintLabel" text="Press Options (*) for full screen" height="26" color="0xFFFFFF" horizAlign="center" vertAlign="center" font="font:SmallestSystemFont" />
+            <Timer id="fullScreenHintTimer" duration="5" />
+            <Timer id="trickplayUITimer" duration="5" />
         </Rectangle>
     </children>
 </component>


### PR DESCRIPTION
First OK press now shows Video UI.
It's achievable via hidden Roku Video node property `showUI`, which allows you to override how trickplay should be displayed by specifying parts of the UI to be rendered (like 'titleAndTime', 'trickplayBar', e.t.c). A timer is started every time custom UI is shown to prevent UI from staying forever.

Second OK press while UI is visible pauses the video (pause poster animation is not added yet).

However, since we shouldn't break default OK button actions, we must track whether user is seeking in video UI and if they do, fallback to Video internal OK handler.

Also, auto-formatted VideoPlayer.xml