### PR TITLE
Add a hint to error message when login is required to view video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Added a "hint" in the error message when playing a video and login is required.
+
 ## [0.40.2] - 2025-06-12
 
 ### Added

--- a/playlet-lib/src/components/Services/Innertube/PlayerEndpoint.bs
+++ b/playlet-lib/src/components/Services/Innertube/PlayerEndpoint.bs
@@ -99,26 +99,35 @@ namespace Innertube
             return "Invalid playability status"
         end if
 
-        if playabilityStatus["status"] = "OK"
+        status = ValidString(playabilityStatus["status"])
+        if status = "OK"
             return ""
         end if
 
-        errorMessage = ""
-        if IsString(playabilityStatus["reason"])
-            errorMessage = playabilityStatus["reason"]
+        errorLines = []
+        if not StringUtils.IsNullOrEmpty(playabilityStatus["reason"])
+            errorLines.Push(playabilityStatus["reason"])
+        end if
+
+        if not StringUtils.IsNullOrEmpty(playabilityStatus["reasonTitle"])
+            errorLines.Push(playabilityStatus["reasonTitle"])
         end if
 
         subreason = ParseText(ObjectUtils.Dig(playabilityStatus, ["errorScreen", "playerErrorMessageRenderer", "subreason"]))
-
         if subreason <> ""
-            errorMessage += `\n` + subreason
+            errorLines.Push(subreason)
         end if
 
-        if errorMessage = ""
-            errorMessage = "Video not available"
+        if errorLines.Count() = 0
+            errorLines.Push("Video not available (Unknown)")
         end if
 
-        return errorMessage
+        if status = "LOGIN_REQUIRED"
+            ' TODO:P2 localize
+            errorLines.Push("Hint: Log in to the YouTube app on your phone, then cast the video to Playlet.")
+        end if
+
+        return errorLines.Join(`\n`)
     end function
 
     function ParseStoryboards(payload as object, lengthSeconds as integer) as object


### PR DESCRIPTION
#651 A workaround exists, but it is not documented.
This adds a hint suggesting how to play the video (by casting from YouTube app)