### PR TITLE
Release v0.41.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.41.20] - 2025-09-21
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet",
-            "version": "0.41.19",
+            "version": "0.41.20",
             "hasInstallScript": true,
             "devDependencies": {
                 "@rokucommunity/bslint": "^0.8.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "description": "Unofficial YouTube client for Roku",
     "devDependencies": {
         "@rokucommunity/bslint": "^0.8.35",

--- a/playlet-app/package-lock.json
+++ b/playlet-app/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet-app",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet-app",
-            "version": "0.41.19"
+            "version": "0.41.20"
         }
     }
 }

--- a/playlet-app/package.json
+++ b/playlet-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet-app",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "description": "Unofficial YouTube client for Roku",
     "scripts": {
         "prebuild": "rm -rf ../build/playlet-app",

--- a/playlet-app/src/manifest
+++ b/playlet-app/src/manifest
@@ -3,7 +3,7 @@ title=Playlet
 # Do not update version manually, it is auto updated from package.json
 major_version=0
 minor_version=41
-build_version=00019
+build_version=00020
 
 ui_resolutions=hd
 uri_resolution_autosub=$$RES$$,480p,720p,1080p

--- a/playlet-lib/package-lock.json
+++ b/playlet-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet-lib",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet-lib",
-            "version": "0.41.19"
+            "version": "0.41.20"
         }
     }
 }

--- a/playlet-lib/package.json
+++ b/playlet-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet-lib",
-    "version": "0.41.19",
+    "version": "0.41.20",
     "description": "Unofficial YouTube client for Roku",
     "scripts": {
         "prebuild": "rm -rf ../build/playlet-lib",

--- a/playlet-lib/src/manifest
+++ b/playlet-lib/src/manifest
@@ -3,7 +3,7 @@ title=PlayletLib
 # Do not update version manually, it is auto updated from package.json
 major_version=0
 minor_version=41
-build_version=00019
+build_version=00020
 
 ui_resolutions=hd
 uri_resolution_autosub=$$RES$$,480p,720p,1080p

--- a/playlet-web/package-lock.json
+++ b/playlet-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playlet-web",
-  "version": "0.41.19",
+  "version": "0.41.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playlet-web",
-      "version": "0.41.19",
+      "version": "0.41.20",
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
         "@tailwindcss/postcss": "^4.1.13",

--- a/playlet-web/package.json
+++ b/playlet-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playlet-web",
-  "version": "0.41.19",
+  "version": "0.41.20",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release 0.41.20. See CHANGELOG.md and roadmap #6 for details.