### PR TITLE
Prioritise manually created subtitles over auto-generated ones

### DIFF
--- a/playlet-lib/src/components/Services/Innertube/PlayerEndpoint.bs
+++ b/playlet-lib/src/components/Services/Innertube/PlayerEndpoint.bs
@@ -316,6 +316,7 @@ namespace Innertube
         end if
 
         captions = []
+        autoCaptions = []
         for each track in tracks
             if not IsAssociativeArray(track)
                 continue for
@@ -341,13 +342,22 @@ namespace Innertube
 
             label = ParseText(track["name"])
 
-            captions.Push({
+            thisCaption = {
                 "label": label
                 "language_code": languageCode
                 "url": baseUrl
-            })
+            }
+
+            if track["kind"] = "asr"
+                autoCaptions.Push(thisCaption)
+                continue for
+            end if
+
+            captions.Push(thisCaption)
         end for
 
+        ' Put automatically generated captions at the end so human-generated ones take priority
+        captions.Append(autoCaptions)
         return captions
     end function
 


### PR DESCRIPTION
At the moment, there are two problems with the caption support in my experience:

1. Roku ignores the description provided and replaces it with a language name
2. Auto-generated subtitles are given priority over manually-created ones, at least in some cases

These two combine to mean that for some videos (e.g. https://www.youtube.com/watch?v=Ja5BDtMybBA ) there are two subtitle tracks, both just with the label "English", one of which is hand-crafted to add to the experience, and the other of which is pretty terrible, and the latter is chosen as the default subtitles.

I've verified this change works for me on a Roku Streaming Stick Something or other, using all default settings.

I don't know BrightScript and I can't say learning it more is one of my life goals, so I won't be surprised if there are hidden issues in this code that *seems* to work for me, and I don't want to go too deeply into things like tests without knowing whether this is a reasonable approach.