### PR TITLE
Add preference to disable auto-dubbed audi tracks

### DIFF
--- a/playlet-lib/src/components/Services/Dash/DashManifest.bs
+++ b/playlet-lib/src/components/Services/Dash/DashManifest.bs
@@ -7,9 +7,11 @@ import "pkg:/source/utils/UrlUtils.bs"
 class DashManifest
 
     public invidiousInstance as dynamic
+    public disableAutoDubbed as boolean
 
-    function new(invidiousInstance as string)
+    function new(invidiousInstance as string, disableAutoDubbed = false as boolean)
         m.invidiousInstance = invidiousInstance
+        m.disableAutoDubbed = disableAutoDubbed
 
         m.utils = new Http.Utils()
 
@@ -279,6 +281,9 @@ class DashManifest
     function GenerateAudioAdaptationSets(xml as object, audioGroups as object, id as integer, metadata as object) as integer
         for each group in audioGroups
             firstFormat = group[0]
+            if m.disableAutoDubbed and ValidBool(firstFormat.isAutoDubbed)
+                continue for
+            end if
             hoisted = {}
 
             adaptationSetAttributes = {

--- a/playlet-lib/src/components/Web/PlayletWebServer/Middleware/DashRouter.bs
+++ b/playlet-lib/src/components/Web/PlayletWebServer/Middleware/DashRouter.bs
@@ -12,6 +12,7 @@ namespace Http
 
             m.videoQueueNode = server.sceneNodes.videoQueue
             m.invidiousNode = server.sceneNodes.invidious
+            m.preferencesNode = server.sceneNodes.preferences
             m.invidiousService = new Invidious.InvidiousService(m.invidiousNode)
             ' No need to pass the invidious instance here, we will refresh it for
             ' each request to make sure we are using the latest one
@@ -51,6 +52,7 @@ namespace Http
             end if
 
             m.dashManifest.invidiousInstance = m.invidiousService.GetInstance()
+            m.dashManifest.disableAutoDubbed = ValidBool(m.preferencesNode["playback.disable_auto_dubbed"])
 
             qualityFilter = m.CreateQualityFilter(quality)
             xmlContent = m.dashManifest.FromVideoMetadata(metadata, qualityFilter, ValidString(local) = "true")

--- a/playlet-lib/src/config/preferences.json5
+++ b/playlet-lib/src/config/preferences.json5
@@ -27,6 +27,13 @@
         visibility: "web",
         svelteComponent: "EditQualityControl",
       },
+      {
+        displayText: "Disable auto-dubbed audio",
+        key: "playback.disable_auto_dubbed",
+        description: "Remove AI-generated dubbed audio tracks.",
+        type: "boolean",
+        defaultValue: false,
+      },
     ],
   },
   {

--- a/playlet-lib/src/locale/en_US/translations.ts
+++ b/playlet-lib/src/locale/en_US/translations.ts
@@ -801,6 +801,14 @@
         <translation>Feed preferences</translation>
     </message>
     <message>
+        <source>Disable auto-dubbed audio</source>
+        <translation>Disable auto-dubbed audio</translation>
+    </message>
+    <message>
+        <source>Remove AI-generated dubbed audio tracks.</source>
+        <translation>Remove AI-generated dubbed audio tracks.</translation>
+    </message>
+    <message>
         <source>Disable Shorts</source>
         <translation>Disable Shorts</translation>
     </message>

--- a/playlet-lib/src/source/utils/Locale.bs
+++ b/playlet-lib/src/source/utils/Locale.bs
@@ -253,6 +253,9 @@ namespace Locale
         PreferredQualityDescription = "Preferred video quality"
         AutoQuality = "Auto"
 
+        DisableAutoDubbedAudio = "Disable auto-dubbed audio"
+        DisableAutoDubbedAudioDescription = "Remove AI-generated dubbed audio tracks."
+
         Backend = "Backend"
         BackendPreferences = "Backend preferences"
         SelectedBackend = "Selected backend"


### PR DESCRIPTION
YouTube has been rolling out AI-generated dubbed audio tracks on videos. Roku's player automatically selects the dubbed track matching the device language, overriding the original audio — and the app provides no way to switch back. The only workaround is a cumbersome device-level setting.

This adds a "Disable auto-dubbed audio" boolean preference under Playback settings. When enabled, auto-dubbed audio groups (identified by the existing isAutoDubbed flag from xtags parsing) are excluded from the locally-generated DASH manifest, so only the original audio track is available for playback.

A softer approach — keeping dubbed tracks available but defaulting to the original — was also investigated. Both DASH `selectionPriority` attributes and AdaptationSet reordering were tested on a Roku TV, but Roku's player ignores both and always selects the track matching the device language. Removing the tracks from the manifest is the only reliable approach.

Tested on a Hisense 65R6107 (Roku OS). With the preference enabled, auto-dubbed tracks are no longer listed and the original audio plays by default. With the preference disabled (default), behavior is unchanged.

Scope: DASH (local) path only. HLS and DRM DASH paths are not yet covered and could be addressed in follow-up work.

Fixes #714