### PR TITLE
Release v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.48.0] - 2026-07-01
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet",
-            "version": "0.47.5",
+            "version": "0.48.0",
             "hasInstallScript": true,
             "devDependencies": {
                 "@rokucommunity/bslint": "^0.8.44",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "description": "Unofficial YouTube client for Roku",
     "devDependencies": {
         "@rokucommunity/bslint": "^0.8.44",

--- a/playlet-app/package-lock.json
+++ b/playlet-app/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet-app",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet-app",
-            "version": "0.47.5"
+            "version": "0.48.0"
         }
     }
 }

--- a/playlet-app/package.json
+++ b/playlet-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet-app",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "description": "Unofficial YouTube client for Roku",
     "scripts": {
         "prebuild": "node ../tools/rm.js ../build/playlet-app",

--- a/playlet-app/src/manifest
+++ b/playlet-app/src/manifest
@@ -2,8 +2,8 @@ title=Playlet
 
 # Do not update version manually, it is auto updated from package.json
 major_version=0
-minor_version=47
-build_version=00005
+minor_version=48
+build_version=00000
 
 ui_resolutions=hd
 uri_resolution_autosub=$$RES$$,480p,720p,1080p

--- a/playlet-lib/package-lock.json
+++ b/playlet-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "playlet-lib",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "playlet-lib",
-            "version": "0.47.5"
+            "version": "0.48.0"
         }
     }
 }

--- a/playlet-lib/package.json
+++ b/playlet-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playlet-lib",
-    "version": "0.47.5",
+    "version": "0.48.0",
     "description": "Unofficial YouTube client for Roku",
     "scripts": {
         "prebuild": "node ../tools/rm.js ../build/playlet-lib",

--- a/playlet-lib/src/manifest
+++ b/playlet-lib/src/manifest
@@ -2,8 +2,8 @@ title=PlayletLib
 
 # Do not update version manually, it is auto updated from package.json
 major_version=0
-minor_version=47
-build_version=00005
+minor_version=48
+build_version=00000
 
 ui_resolutions=hd
 uri_resolution_autosub=$$RES$$,480p,720p,1080p

--- a/playlet-web/package-lock.json
+++ b/playlet-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playlet-web",
-  "version": "0.47.5",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playlet-web",
-      "version": "0.47.5",
+      "version": "0.48.0",
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/postcss": "^4.3.1",

--- a/playlet-web/package.json
+++ b/playlet-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playlet-web",
-  "version": "0.47.5",
+  "version": "0.48.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release 0.48.0. See CHANGELOG.md and roadmap #6 for details.